### PR TITLE
Add Ollama Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,38 @@ A Thunderbird extension that helps improve your email writing using various AI m
 
 ### Multiple AI Models Support
 
-| **OpenAI Models** | **Groq Models**         | **Google Models** |
-| ----------------- | ----------------------- | ----------------- |
-| GPT-4 Turbo       | Llama 3.3 70B Versatile | Gemini 2.0 Flash  |
-| GPT-4 Turbo Mini  | Llama 3.2 3B Preview    |                   |
-| GPT-3.5 Turbo     |                         |                   |
+| **OpenAI**        | **Groq**                | **Google**        | **Selfhosted/Other** |
+| ----------------- | ----------------------- | ----------------- | -------------------- |
+| GPT-4 Turbo       | Llama 3.3 70B Versatile | Gemini 2.0 Flash  | [Ollama](https://github.com/ollama/ollama?tab=readme-ov-file#model-library) (\*) |
+| GPT-4 Turbo Mini  | Llama 3.2 3B Preview    |                   |                      |
+| GPT-3.5 Turbo     |                         |                   |                      |
 
-API keys for at least one model are required to use the extension. You can obtain API keys from the respective AI service providers.
+API keys are required to use the extension with non-self-hosted models. You can obtain API keys from the respective AI service providers.
+
+(\*) Requires to set 'OLLAMA_ORIGINS "moz-extension://*" as described [here (github.com)](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-allow-additional-web-origins-to-access-ollama).
 
 ### Customizable Settings
 
+- **Model Selection**: Choose your preferred AI model
+- **Custom Prompts**: Set your own prompt for email improvement
 - **Temperature Control**: Adjust the creativity level (0-2)
   - Lower values (0-1): More focused and deterministic responses
   - Higher values (1-2): More creative and diverse responses
 - **Max Tokens**: Control the maximum length of AI responses (1-4000)
-- **Custom Prompts**: Set your own prompt for email improvement
-- **Model Selection**: Choose your preferred AI model
 
 Settings can be accessed from the Thunderbird add-ons list.
 
 ### Privacy & Transparency
 
-- Your email content is only sent to the AI service when you click the improve button. Keep in mind that the AI service may handle and store your data according to their privacy policy.
+- Your email content is only sent to the AI service when you click the "Improve Writing" button. Keep in mind that the AI service may handle and store your data according to their privacy policy. If your hardware supports it, use self-hosted models for better privacy.
 - No data is stored locally except for your settings
 - API keys are stored securely in your browser's local storage.
 - The extension is **open-source** and kept **simple for transparency**. You can review the code and contribute to the project.
 
 ## 🚀 Installation
 
-1. Download the extension zib file from the releases page.
-2. In Thunderbird, go to **Tools > Add-ons**
+1. Download the extension '.zib' file from the releases page.
+2. In Thunderbird, go to _Tools > Add-ons_
 3. Click the gear icon > _Install Add-on From File_
 4. Choose the downloaded file
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Settings can be accessed from the Thunderbird add-ons list.
 
 ### Privacy & Transparency
 
-- Your email content is only sent to the AI service when you click the "Improve Writing" button. Keep in mind that the AI service may handle and store your data according to their privacy policy. If your hardware supports it, use self-hosted models for better privacy.
+- Your email content is only sent to the AI service when you click the "Improve Writing" button. Keep in mind that the AI service may handle and store your data according to their privacy policy. If your hardware supports it, **use self-hosted models for better privacy**.
 - No data is stored locally except for your settings
 - API keys are stored securely in your browser's local storage.
 - The extension is **open-source** and kept **simple for transparency**. You can review the code and contribute to the project.

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,8 @@
 {
   "manifest_version": 2,
   "name": "AI Writing Assistant",
-  "version": "1.0",
-  "description": "Improve your email writing style using Groq AI",
-  "author": "Your Name",
+  "version": "0.2.0",
+  "description": "Improve your email writing style using AI.",
   "applications": {
     "gecko": {
       "id": "groq-writing-assistant@example.com",

--- a/options.html
+++ b/options.html
@@ -26,6 +26,14 @@
         padding: 8px;
         border: 1px solid #ccc;
         border-radius: 4px;
+        box-sizing: border-box;
+      }
+      textarea {
+        width: 100%;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
       }
       button {
         background-color: #0060df;
@@ -37,6 +45,9 @@
       }
       button:hover {
         background-color: #003eaa;
+      }
+      details[open] summary {
+        margin-bottom: 0.5em;
       }
       .status {
         margin-top: 20px;
@@ -95,14 +106,10 @@
     </div>
     <div class="container">
       <h1>AI Writing Assistant Settings</h1>
-      <div class="form-group">
-        <label for="apiKey">API Key:</label>
-        <input
-          type="text"
-          id="apiKey"
-          placeholder="Enter your API key for the provider of model you want to use."
-        />
-      </div>
+      <p class="form-group" style="font-size: 0.9em; color: #5e636e">
+        A Thunderbird extension that helps improve your email writing using various AI models (LLMs) and customizable prompts. Feel free to 
+        contribute or report bugs on <a href="https://github.com/luiskugel/AI-Writing-Assistant-for-Thunderbird" target="_blank">Github</a>.
+      </p>
       <div class="form-group">
         <label for="model">AI Model:</label>
         <select
@@ -114,91 +121,146 @@
             border-radius: 4px;
           "
         >
-          <option value="openai:gpt-4o">OpenAI GPT-4o</option>
-          <option value="openai:gpt-4o-mini">OpenAI GPT-4o Mini</option>
-          <option value="openai:o3-mini">OpenAI O3 mini</option>
+          <option value="openai:gpt-4o">
+            OpenAI: GPT-4o
+          </option>
+          <option value="openai:gpt-4o-mini">
+            OpenAI: GPT-4o Mini
+          </option>
+          <option value="openai:o3-mini">
+            OpenAI: O3 mini
+          </option>
           <option value="openai:gpt-4.5-preview">
-            OpenAI GPT-4.5 Preview (very expensive)
+            OpenAI: GPT-4.5 Preview (very expensive)
           </option>
           <option value="groq:llama-3.3-70b-versatile">
-            Groq Llama 3.3 70B Versatile 128k
+            Groq: Llama 3.3 70B Versatile 128k
           </option>
           <option value="groq:llama-3.2-3b-preview">
             Groq: Llama 3.2 3B (Preview) 8k
           </option>
           <option value="google:gemini-2.0-flash">
-            Google Gemini 2.0 Flash
+            Google: Gemini 2.0 Flash
           </option>
-        </select>
+          <option value="custom:">
+            custom: Ollama API & Models
+          </select>
       </div>
       <div class="form-group">
-        <label for="temperature">Temperature (Creativity Level):</label>
-        <div style="display: flex; align-items: center; gap: 10px">
-          <input
-            type="range"
-            id="temperature"
-            min="0"
-            max="2"
-            value="0.7"
-            step="0.01"
-            style="flex: 1"
-          />
-          <span id="temperatureValue">0.70</span>
-        </div>
-        <div style="font-size: 0.9em; color: #666; margin-top: 5px">
-          Lower values (0-1) make responses more focused and deterministic,
-          higher values (1-2) make responses more creative and diverse.
-        </div>
+        <label for="apiKey">API Key:</label>
+        <input
+          type="text"
+          id="apiKey"
+          placeholder="Enter your API key for the provider of model you want to use."
+        />
       </div>
-      <div class="form-group">
-        <label for="maxTokens">Max Tokens (Response Length):</label>
-        <div style="display: flex; align-items: center; gap: 10px">
-          <input
-            type="number"
-            id="maxTokens"
-            min="1"
-            max="4000"
-            value="2000"
+      <div class="form-group" id="customApiEndpointGroup" style="display: none;">
+        <label for="customApiEndpoint">Custom API URL:</label>
+        <input
+          type="text"
+          id="customApiEndpoint"
+          placeholder="http://localhost:11434/api/generate"
+          style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px;"
+        />
+      </div>
+      <div class="form-group" id="customModelGroup" style="display: none;">
+        <label for="customModel">Custom Model:</label>
+        <input
+          type="text"
+          id="customModel"
+          placeholder="phi4-mini (lookup your installed models)"
+          style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px;"
+        />
+      </div>
+      <details class="form-group">
+        <summary>More Settings</summary>
+        <div class="form-group">
+          <label for="prompt">Improvement Prompt:</label>
+          <textarea
+            id="promptImprove"
+            rows="4"
             style="
               width: 100%;
               padding: 8px;
               border: 1px solid #ccc;
               border-radius: 4px;
             "
-          />
+            placeholder="Enter the prompt to use for improving mails"
+          ></textarea>
         </div>
-        <div style="font-size: 0.9em; color: #666; margin-top: 5px">
-          Maximum number of tokens in the response. Higher values allow for
-          longer responses but may increase processing time and cost.
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="prompt">Improvement Prompt:</label>
-        <textarea
-          id="promptImprove"
-          rows="4"
-          style="
-            width: 100%;
-            padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-          "
-          placeholder="Enter the prompt to use for improving mails"
-        ></textarea>
-      </div>
-      <div class="form-group">
-        <label for="promptHtml2Text">Html2Text Prompt:</label>
-        <textarea
-          id="promptHtml2Text"
-          rows="4"
-          style="
-            width: 100%;
-            padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-          "
-          placeholder="Enter the prompt to use for Html2Text"
-        ></textarea>
+        <div class="form-group">
+          <label for="promptHtml2Text">Html2Text Prompt:</label>
+          <textarea
+            id="promptHtml2Text"
+            rows="4"
+            style="
+              width: 100%;
+              padding: 8px;
+              border: 1px solid #ccc;
+              border-radius: 4px;
+            "
+            placeholder="Enter the prompt to use for Html2Text"
+          ></textarea>
+          <div class="form-group">
+            <label for="temperature">Temperature (Creativity Level):</label>
+            <div style="display: flex; align-items: center; gap: 10px">
+              <input
+                type="range"
+                id="temperature"
+                min="0"
+                max="2"
+                value="0.7"
+                step="0.01"
+                style="flex: 1"
+              />
+              <span id="temperatureValue">0.70</span>
+            </div>
+            <div style="font-size: 0.9em; color: #666; margin-top: 5px">
+              Lower values (0-1) make responses more focused and deterministic,
+              higher values (1-2) make responses more creative and diverse.
+            </div>
+          </div>
+            <div class="form-group"></div>
+            <label for="maxTokens">Max Tokens (Response Length):</label>
+            <div style="display: flex; align-items: center; gap: 10px">
+              <input
+              type="number"
+              id="maxTokens"
+              min="1"
+              max="4000"
+              value="2000"
+              style="
+                width: 100%;
+                padding: 8px;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+              "
+              />
+            </div>
+            <div style="font-size: 0.9em; color: #666; margin-top: 5px">
+              Maximum number of tokens in the response. Higher values allow for
+              longer responses but may increase processing time and cost.
+            </div>
+            </div>
+            <div class="form-group">
+            <label for="useConversationHistory">Use Conversation History:</label>
+            <div style="display: flex; align-items: center; gap: 10px">
+              <input
+              type="checkbox"
+              id="useConversationHistory"
+              style="
+                width: auto;
+                padding: 8px;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+              "
+              />
+              <span style="font-size: 0.9em; color: #666">
+                Use Conversation History for email draft generation. Recomended to disable for weeker generation models.
+              </span>
+            </div>
+            </div>
+      </details>
       <button id="save">Save Settings</button>
       <div id="status" class="status" style="display: none"></div>
     </div>

--- a/options.js
+++ b/options.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", async () => {
-  // Load saved settings
+  // Initially load saved settings
   const result = await browser.storage.local.get([
     "promptImprove",
     "promptHtml2Text",
@@ -7,35 +7,35 @@ document.addEventListener("DOMContentLoaded", async () => {
     "apiKey",
     "temperature",
     "maxTokens",
-  ]);
+    "useConversationHistory",
+  ]); 
+  if (result.selectedModel) {
+    document.getElementById("model").value = result.selectedModel;
+  }
   if (result.apiKey) {
     document.getElementById("apiKey").value = result.apiKey;
   }
   if (result.promptImprove) {
     document.getElementById("promptImprove").value = result.promptImprove;
   } else {
-    document.getElementById("promptImprove").value =`Du erhältst eine E-Mail im HTML- oder Textformat. Deine Aufgabe: Überarbeite ausschließlich den Draft-Teil und formuliere daraus eine vollständige E-Mail im HTML-Format in der Sprache die auch im Draft verwendet wird.
-Vorgehensweise:
-1. Strukturiere den Inhalt logisch und leserfreundlich.
-2. Formuliere die E-Mail klar, prägnant und übersichtlich. Halte dich dabei an folgende Regeln:
-  - Keine unnötigen Adjektive
-  - Klare, kurze und präzise Sprache
-  - Alle Stichpunkte müssen vollständig und inhaltlich korrekt enthalten sein
-  - Der Text muss leicht überfliegbar und schnell erfassbar sein.
-3. Gib ausschließlich den plain HTML-Code ohne codeblock formatierung zurück, der den Draft-Teil ersetzt.
-Wichtig: 
-  - Der Kontext-/Verlaufsteil dient nur zur Orientierung, er soll nicht verändert oder ausgegeben werden.
-  - Der HTML-Code einer ggf vorhandenen Signatur darf nicht verändert werden.
-  `;
+    document.getElementById("promptImprove").value =`You will receive an email in HTML or plain text format, along with a context history. Your task is to revise the email draft only. Use the context solely for informational guidance - do NOT include it in your output.
+Rules:
+1. Structure: Clear, logical, and easy to read.
+2. Language:
+   - Use the same language as in the draft.
+   - Write clearly, politely, and concisely. Avoid unnecessary adjectives.
+3. Content: All bullet points from the draft must be included fully and accurately.
+4. Text formatting: Return only standard, well-formatted email text.
+5. Format: Return only HTML - no metadata, no subject line, no additional explanations.
+6. HTML structure: Keep <html>, <body>, etc., exactly as in the draft. Leave open tags open if they are open in the draft.
+7. Signature (if present): Do not modify.
+
+Only the section between <!-- BEGIN DRAFT --> and <!-- END DRAFT --> should be revised. The section between <!-- BEGIN CONTEXT --> and <!-- END CONTEXT --> is for reference only.`;
   }
   if (result.promptHtml2Text) {
     document.getElementById("promptHtml2Text").value = result.promptHtml2Text;
   } else {
-    document.getElementById("promptHtml2Text").value = `Du erhältst eine E-Mail im HTML-Format. Deine Aufgabe ist es, den HTML-Code in einen lesbaren Text umzuwandeln.
-    `;
-  }
-  if (result.selectedModel) {
-    document.getElementById("model").value = result.selectedModel;
+    document.getElementById("promptHtml2Text").value = `Du erhältst eine E-Mail im HTML-Format. Deine Aufgabe ist es, den HTML-Code in einen lesbaren Text umzuwandeln.`;
   }
   if (result.temperature !== undefined) {
     document.getElementById("temperature").value = result.temperature;
@@ -45,6 +45,27 @@ Wichtig:
   if (result.maxTokens !== undefined) {
     document.getElementById("maxTokens").value = result.maxTokens;
   }
+  if (result.customApiEndpoint !== undefined) {
+    document.getElementById("customApiEndpoint").value = result.customApiEndpoint;
+  } else {
+    document.getElementById("customApiEndpoint").value = "http://localhost:11434/api/chat";
+  }
+  if (result.customModel !== undefined) {
+    document.getElementById("customModel").value = result.customModel;
+  }
+  if (result.useConversationHistory !== undefined) {
+    document.getElementById("useConversationHistory").checked = result.useConversationHistory;
+  } else {
+    document.getElementById("useConversationHistory").checked = true;
+  }
+  
+  // Handle conditional display of inputs
+  const modelSelect = document.getElementById("model");
+  modelSelect.addEventListener("change", () => {
+    const isCustom = modelSelect.value === "custom:";
+    document.getElementById("customApiEndpointGroup").style.display = isCustom ? "block" : "none";
+    document.getElementById("customModelGroup").style.display = isCustom ? "block" : "none";
+  });
 
   // Handle temperature slider changes
   document.getElementById("temperature").addEventListener("input", (e) => {
@@ -54,16 +75,29 @@ Wichtig:
 
   // Handle save button click
   document.getElementById("save").addEventListener("click", async () => {
+    const model = document.getElementById("model").value;
     const apiKey = document.getElementById("apiKey").value.trim();
     const promptImprove = document.getElementById("promptImprove").value.trim();
     const promptHtml2Text = document.getElementById("promptHtml2Text").value.trim();
-    const model = document.getElementById("model").value;
+    const customApiEndpoint = document.getElementById("customApiEndpoint").value;
+    const customModel = document.getElementById("customModel").value;
     const temperature = parseFloat(
       document.getElementById("temperature").value
     );
     const maxTokens = parseInt(document.getElementById("maxTokens").value);
+    const useConversationHistory = document.getElementById("useConversationHistory").checked;
 
-    if (!apiKey) {
+    if (model === "custom:") {
+      if (!customModel) {
+        showStatus("Please enter a custom model", "error");
+        return;
+      }
+      if (!customApiEndpoint) {
+        showStatus("Please enter a custom API endpoint", "error");
+        return;
+      }
+    }
+    if (!apiKey && model !== "custom:") {
       showStatus("Please enter an API key", "error");
       return;
     }
@@ -90,8 +124,11 @@ Wichtig:
         promptImprove: promptImprove,
         promptHtml2Text: promptHtml2Text,
         selectedModel: model,
+        customApiEndpoint: customApiEndpoint,
+        customModel: customModel,
         temperature: temperature,
         maxTokens: maxTokens,
+        useConversationHistory: useConversationHistory,
       });
       showStatus("Settings saved successfully!", "success");
     } catch (error) {

--- a/options.js
+++ b/options.js
@@ -7,6 +7,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     "apiKey",
     "temperature",
     "maxTokens",
+    "customApiEndpoint",
+    "customModel",
     "useConversationHistory",
   ]); 
   if (result.selectedModel) {


### PR DESCRIPTION
- **Ollama Support**
  - Custom (selfhosted) endpoint and model can now be configured.
- **Enhanced support for weaker self-hosted models (e.g. phi4-mini)**
  - Adjusted prompt structure for improved comprehension.
  - Added option to exclude conversation history from LLM context input.
  - Collapsed less frequently used options in the options menu to reduce visual clutter
- Todo: Error handling in general, add-on description and links.